### PR TITLE
Open tty in write mode but not append

### DIFF
--- a/easyjump.py
+++ b/easyjump.py
@@ -281,12 +281,12 @@ class Screen:
         return raw_with_labels
 
     def _enter_alternate(self) -> None:
-        with open(self._tty, "a") as f:
+        with open(self._tty, "w") as f:
             f.write("\033[?1049h")
         self._alternate_on = True
 
     def _update(self, raw: str) -> None:
-        with open(self._tty, "a") as f:
+        with open(self._tty, "w") as f:
             f.write("\033[2J\033[H\033[0m")
             f.write(raw)
             cursor_x, cursor_y = self._cursor_pos[-1]
@@ -295,7 +295,7 @@ class Screen:
             self._copy_mode.scroll_position += self._height  # raw.count("\n") + 1
 
     def _leave_alternate(self) -> None:
-        with open(self._tty, "a") as f:
+        with open(self._tty, "w") as f:
             f.write("\033[?1049l")
         self._alternate_on = False
 


### PR DESCRIPTION
Appending tty fails on platform like Android Termux. And opening tty
in write mode is enough to send ANSI escape sequences for jumping.

---

I encountered a problem when trying tmux on Android Termux today.

```
Traceback (most recent call last):
  File "/data/data/com.termux/files/home/.local/share/tmux/plugins/easyjump.tmux/easyjump.py", line 732, in <module>
    main()
  File "/data/data/com.termux/files/home/.local/share/tmux/plugins/easyjump.tmux/easyjump.py", line 720, in main
    with screen.label_positions(positions, assigned_labels):
  File "/data/data/com.termux/files/usr/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/data/data/com.termux/files/home/.local/share/tmux/plugins/easyjump.tmux/easyjump.py", line 245, in label_positions
    self._enter_alternate()
  File "/data/data/com.termux/files/home/.local/share/tmux/plugins/easyjump.tmux/easyjump.py", line 284, in _enter_alternate
    with open(self._tty, "a") as f:
PermissionError: [Errno 13] Permission denied: '/dev/pts/5'
```

Writing to tty with `echo Hello > /dev/pts/5` does succeed. The pseudo tty could not be open in `a`ppend mode. 

Considering we open tty only for writing ANSI escape sequences, `w`rite mode seems to be enough.