### PR TITLE
fix(get_option): replace echo with printf in get_option

### DIFF
--- a/easyjump.tmux
+++ b/easyjump.tmux
@@ -70,7 +70,7 @@ def check_requirements() -> None:
 
 
 def get_option(option_name: str) -> str:
-    args = ["sh", "-c", "echo -e \"$(tmux show-option -gqv '" + option_name + "')\""]
+    args = ["sh", "-c", "printf \"$(tmux show-option -gqv '" + option_name + "')\n\""]
     proc = subprocess.run(args, check=True, capture_output=True)
     option_value = proc.stdout.decode()[:-1]
     return option_value


### PR DESCRIPTION
The `get_option` function was using `echo -e` to print the output of a subprocess call.

However, in many versions of `sh`, `echo` doesn't support the `-e` option, and `-e` is treated as a literal string rather than a flag to enable escape sequence interpretation.

This has been replaced with `printf` to ensure that escape sequences are handled correctly and the output is formatted as expected regardless of the shell, and the function has a consistent behavior across different environments.